### PR TITLE
refactor(share): move affiliateID from params to searchParams

### DIFF
--- a/src/app/share/[type]/page.tsx
+++ b/src/app/share/[type]/page.tsx
@@ -6,18 +6,19 @@ import { notFound } from 'next/navigation'
 interface Props {
     params: {
         type: string;
-        affiliateID: string;
+
 
     },
     searchParams: {
-        id: string
+        id: string;
+        affiliateID: string;
     }
 }
 
 export default async function SharePage({ params, searchParams }: Props) {
     // MAKE SURE YOU AWAIT THE PARAMS
-    const { type, affiliateID } = await params
-    const { id } = await searchParams;
+    const { type } = await params
+    const { id, affiliateID } = await searchParams;
 
     // state 
     const setAffilateID = useSetAtom(affiliateIDAtom);


### PR DESCRIPTION
The affiliateID parameter is more appropriately placed in searchParams as it's typically passed via URL query parameters rather than route parameters. This change aligns with common URL parameter conventions.