### PR TITLE
feat(auth): add sign-in link for existing accounts

### DIFF
--- a/src/components/Custom/modals/FundRaiserModal/FundRaiserAccountSetup.tsx
+++ b/src/components/Custom/modals/FundRaiserModal/FundRaiserAccountSetup.tsx
@@ -64,7 +64,8 @@ function FundRaiserAccountSetup() {
         const user_id = localStorage.getItem(STORAGE_KEYS.USER_ID);
         return token !== null && user_id !== null;
     });
-    const [googleAuthUsed, setGoogleAuthUsed] = React.useState(() => localStorage.getItem(STORAGE_KEYS.GOOGLE_AUTH))
+    const [googleAuthUsed, setGoogleAuthUsed] = React.useState(() => localStorage.getItem(STORAGE_KEYS.GOOGLE_AUTH));
+    const [showLink, setShowLink] = React.useState(false);
 
 
     const { data: session, status } = useSession();
@@ -226,7 +227,7 @@ function FundRaiserAccountSetup() {
                 localStorage.setItem(STORAGE_KEYS.CURRENT_STEP, step.toString());
                 localStorage.setItem(STORAGE_KEYS.DONATION_AMOUNT, amount.toString());
                 localStorage.setItem(STORAGE_KEYS.DONATION_DETAILS, JSON.stringify(activeFundRaider))
-                setStep(2);
+                setShowLink(true)
                 toaster.create({
                     title: 'Alert!',
                     description: data?.data?.message,
@@ -332,6 +333,12 @@ function FundRaiserAccountSetup() {
                                 </Flex>
                                 <Box w="full">
                                     <CustomInput name="email" label='Email' isPassword={false} />
+                                    {showLink && (
+                                        <HStack mt="10px">
+                                            <Text color="red">You already have an account on chasecroll, for security reasons</Text>
+                                            <Text color="primaryColor" cursor={'pointer'} onClick={() => setStep(2)} textDecorationLine={'underline'}>Sign in</Text>
+                                        </HStack>
+                                    )}
                                 </Box>
 
                             </VStack>

--- a/src/components/Custom/modals/ProductModal/ProductReviewPage.tsx
+++ b/src/components/Custom/modals/ProductModal/ProductReviewPage.tsx
@@ -71,7 +71,8 @@ function ProductReviewPage() {
         const user_id = localStorage.getItem(STORAGE_KEYS.USER_ID);
         return token !== null && user_id !== null;
     });
-    const [googleAuthUsed, setGoogleAuthUsed] = React.useState(() => localStorage.getItem(STORAGE_KEYS.GOOGLE_AUTH))
+    const [googleAuthUsed, setGoogleAuthUsed] = React.useState(() => localStorage.getItem(STORAGE_KEYS.GOOGLE_AUTH));
+    const [showLink, setShowLink] = React.useState(false);
 
 
     const { data: session, status } = useSession();
@@ -195,7 +196,7 @@ function ProductReviewPage() {
                     description: data?.data?.message,
                     type: 'info',
                 });
-                setStep((prev) => prev + 2);
+                setShowLink(true);
             } else {
                 setUserId(data?.data?.id);
                 setToken(data?.data?.token);
@@ -277,6 +278,12 @@ function ProductReviewPage() {
                                     </HStack>
                                     <Box w="full">
                                         <CustomInput name="email" type='email' label='Email' isPassword={false} />
+                                        {showLink && (
+                                            <HStack mt="10px">
+                                                <Text color="red">You already have an account on chasecroll, for security reasons</Text>
+                                                <Text color="primaryColor" cursor={'pointer'} onClick={() => setStep(3)} textDecorationLine={'underline'}>Sign in</Text>
+                                            </HStack>
+                                        )}
                                     </Box>
 
                                 </VStack>


### PR DESCRIPTION
Add showLink state to display a sign-in link when users with existing accounts attempt to register. This improves security by preventing duplicate account creation and guiding users to the correct authentication flow.